### PR TITLE
build: stop emitting source maps from dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "check": "biome check --write .",
+    "prebuild": "rm -rf dist",
     "build": "tsc -p tsconfig.build.json",
     "test": "bun test",
     "test:e2e": "OPENCODE_MODEL=openai/gpt-5.5 RUN_E2E=1 bun test",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -5,8 +5,8 @@
     "outDir": "./dist",
     "rootDir": "./src",
     "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true
+    "declarationMap": false,
+    "sourceMap": false
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Fixes #5.

## Summary
- Disable `sourceMap` and `declarationMap` in `tsconfig.build.json`. The maps reference TS sources that are not shipped in the npm package, so they were dead weight in the published artifact.
- Add `prebuild: rm -rf dist` so stale outputs cannot survive into a release. `tsc` does not auto-clean its output directory.