### PR TITLE
Align imagegen tool name with package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@
 
 ## Implementation Notes
 
-- The exposed tool is `gpt_image_gen`; it calls the ChatGPT Codex responses endpoint with the hosted `image_generation` tool.
+- The exposed tool is `gpt_imagegen`; it calls the ChatGPT Codex responses endpoint with the hosted `image_generation` tool.
 - Output paths are resolved relative to the OpenCode context directory unless absolute, and existing files are never overwritten; suffixes `-v2` through `-v999` are tried.
 - Reference images are read from paths relative to the OpenCode context directory and are embedded as data URLs after MIME detection.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 [![npm version](https://img.shields.io/npm/v/opencode-gpt-imagegen.svg)](https://www.npmjs.com/package/opencode-gpt-imagegen)
 [![CI](https://github.com/yuji-hatakeyama/opencode-gpt-imagegen/actions/workflows/ci.yml/badge.svg)](https://github.com/yuji-hatakeyama/opencode-gpt-imagegen/actions/workflows/ci.yml)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
-[![status](https://img.shields.io/badge/status-v0.1.0-orange.svg)](#roadmap)
 
 | Auth path | Status | Billing |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ OpenCode auto-installs the package via Bun on next launch — no separate `npm i
 
 ## Usage
 
-Just ask your agent in natural language and `gpt_image_gen` will be picked up.
+Just ask your agent in natural language and `gpt_imagegen` will be picked up.
 
 The three examples below are the **actual outputs of this repo's e2e test suite** — see [`tests/e2e.test.ts`](./tests/e2e.test.ts) for the exact prompts and assertions.
 
@@ -47,7 +47,7 @@ The three examples below are the **actual outputs of this repo's e2e test suite*
 
 ### Example B — auto-versioning
 
-`gpt_image_gen` never overwrites an existing file: when the `out` path is already taken, it picks `-v2`, `-v3`, … instead.
+`gpt_imagegen` never overwrites an existing file: when the `out` path is already taken, it picks `-v2`, `-v3`, … instead.
 
 > Now do the same path but make it a woman in a yellow yukata holding a red wagasa, in a moonlit garden with fireflies. Landscape 1536x1024.
 
@@ -67,7 +67,7 @@ Pass any number of image paths via the `images` argument and the model uses them
 
 | Version | Auth path | Scope | Status |
 |---|---|---|---|
-| **v0.1.0** | ChatGPT subscription | `gpt_image_gen` with optional reference images (generation + reference-guided edits via prompting) | **Released** |
+| **v0.1.0** | ChatGPT subscription | `gpt_imagegen` with optional reference images (generation + reference-guided edits via prompting) | **Released** |
 | **v0.2.0** | OpenAI API key | Adds the API-key billing path: both `generate` (`/v1/images/generations`) and `edit` (`/v1/images/edits`) with reference images | Next |
 | **v0.3.0** | OpenAI API key | Adds **pixel-precise mask inpainting** via `/v1/images/edits` (binary PNG alpha mask) | Planned |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,13 +8,13 @@ import { saveGeneratedImage } from "./output-image"
 const GptImagePlugin: Plugin = async (_input: PluginInput): Promise<Hooks> => {
   return {
     tool: {
-      gpt_image_gen: tool({
+      gpt_imagegen: tool({
         description: [
           "Generate raster images using OpenAI's hosted image_generation tool.",
           "Use for AI-created bitmap visuals such as photos, illustrations, textures, sprites, and mockups.",
           "Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas.",
           "Reference images may be attached through `images`; label each image's role inline in `prompt`, for example: 'Image 1: reference image'.",
-          "For many distinct assets, invoke gpt_image_gen once per requested asset rather than relying on multi-image output; gpt_image_gen returns one image per call.",
+          "For many distinct assets, invoke gpt_imagegen once per requested asset rather than relying on multi-image output; gpt_imagegen returns one image per call.",
           "Requires OpenCode to be authenticated with ChatGPT OAuth. Returns the absolute path of the saved PNG.",
         ].join(" "),
         // https://developers.openai.com/api/docs/guides/image-generation

--- a/tests/e2e.test.ts
+++ b/tests/e2e.test.ts
@@ -78,7 +78,7 @@ function readPngDimensions(buf: Buffer): { width: number; height: number } {
   return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
 }
 
-describe.skipIf(!process.env.RUN_E2E)("gpt_image_gen e2e", () => {
+describe.skipIf(!process.env.RUN_E2E)("gpt_imagegen e2e", () => {
   beforeAll(async () => {
     console.log(`WORKDIR: ${WORKDIR}`)
     console.log(`XDG_CONFIG_HOME: ${XDG_CONFIG_HOME}`)
@@ -90,7 +90,7 @@ describe.skipIf(!process.env.RUN_E2E)("gpt_image_gen e2e", () => {
     "A. man portrait 1024x1536",
     async () => {
       await runOpencode(
-        `Use the gpt_image_gen tool to generate an image at character.png. ` +
+        `Use the gpt_imagegen tool to generate an image at character.png. ` +
           `Content: a man wearing a navy-blue samue and a red hachimaki headband, standing in a garden of cherry blossoms in full bloom. ` +
           `Style: ${STYLE}. Size: 1024x1536 (portrait). Quality: medium.`,
       )
@@ -108,7 +108,7 @@ describe.skipIf(!process.env.RUN_E2E)("gpt_image_gen e2e", () => {
     "B. woman landscape 1536x1024 (auto-versioned)",
     async () => {
       await runOpencode(
-        `Use the gpt_image_gen tool to generate an image at character.png. ` +
+        `Use the gpt_imagegen tool to generate an image at character.png. ` +
           `Content: a woman wearing a yellow yukata and holding a red wagasa parasol, standing in a garden at night with fireflies dancing around her. ` +
           `Style: ${STYLE}. Size: 1536x1024 (landscape). Quality: medium.`,
       )
@@ -126,7 +126,7 @@ describe.skipIf(!process.env.RUN_E2E)("gpt_image_gen e2e", () => {
     "C. compose two characters from A and B references",
     async () => {
       await runOpencode(
-        `Use the gpt_image_gen tool to generate an image at together.png. ` +
+        `Use the gpt_imagegen tool to generate an image at together.png. ` +
           `Pass ./character.png and ./character-v2.png in the images argument. ` +
           `Content: the man from Image 1 (navy samue + red hachimaki) and the woman from Image 2 (yellow yukata + red wagasa) standing side by side ` +
           `on the engawa veranda of an old Japanese house, smiling at the viewer. ` +


### PR DESCRIPTION
## Summary
- Rename the exposed image generation tool from `gpt_image_gen` to `gpt_imagegen` to match the package/repository naming.
- Update README, AGENTS.md, and e2e prompts to use the unified tool name.
- Remove the redundant README status badge because the npm version badge already communicates release status.