### PR TITLE
test: hoist shared PNG fixture into tests/unit/fixtures.ts

### DIFF
--- a/tests/unit/fixtures.ts
+++ b/tests/unit/fixtures.ts
@@ -1,0 +1,9 @@
+// A 1x1 transparent PNG, recognized by file-type from its header bytes.
+export const PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
+
+export const PNG_BUFFER = Buffer.from(PNG_BASE64, "base64")
+
+export function pngDataUrl(buf: Buffer): string {
+  return `data:image/png;base64,${buf.toString("base64")}`
+}

--- a/tests/unit/input-image.test.ts
+++ b/tests/unit/input-image.test.ts
@@ -3,16 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { readReferenceImages } from "../../src/input-image"
-
-// A 1x1 transparent PNG; file-type recognizes it from the header bytes.
-const PNG = Buffer.from(
-  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==",
-  "base64",
-)
-
-function dataUrl(buf: Buffer): string {
-  return `data:image/png;base64,${buf.toString("base64")}`
-}
+import { pngDataUrl as dataUrl, PNG_BUFFER as PNG } from "./fixtures"
 
 let dir: string
 

--- a/tests/unit/output-image.test.ts
+++ b/tests/unit/output-image.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises"
 import os from "node:os"
 import path from "node:path"
 import { buildSavedMessage, pickNonOverwritePath, saveGeneratedImage } from "../../src/output-image"
+import { PNG_BASE64, PNG_BUFFER } from "./fixtures"
 
 let dir: string
 
@@ -15,12 +16,9 @@ afterEach(async () => {
   await rm(dir, { recursive: true, force: true })
 })
 
-// A 1x1 transparent PNG, base64-encoded; just enough to round-trip through saveGeneratedImage.
-const PNG_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg=="
-
 // Place a real PNG at the path so it is occupied; pickNonOverwritePath only checks existence.
 function occupy(p: string): Promise<void> {
-  return writeFile(p, Buffer.from(PNG_BASE64, "base64"))
+  return writeFile(p, PNG_BUFFER)
 }
 
 describe("pickNonOverwritePath", () => {
@@ -82,7 +80,7 @@ describe("saveGeneratedImage", () => {
     expect(result.savedPath).toBe(path.join(dir, "image.png"))
     expect(result.versioned).toBe(false)
     const written = await readFile(result.savedPath)
-    expect(written.equals(Buffer.from(PNG_BASE64, "base64"))).toBe(true)
+    expect(written.equals(PNG_BUFFER)).toBe(true)
   })
 
   test("resolves a relative path against the context directory", async () => {


### PR DESCRIPTION
Hoist the 1x1 transparent PNG base64 that was inlined in two test files into a shared `tests/unit/fixtures.ts`.
The name omits `.test.`, so bun's test runner does not pick it up.
