### PR TITLE
fix: reject empty image_generation result from Codex SSE stream

### DIFF
--- a/src/codex.ts
+++ b/src/codex.ts
@@ -27,7 +27,9 @@ export async function parseImageGenerationResultFromSSE(stream: ReadableStream<U
       if (
         json.type === "response.output_item.done" &&
         json.item?.type === "image_generation_call" &&
-        typeof json.item.result === "string"
+        typeof json.item.result === "string" &&
+        // Reject an empty result: decoding it would write a 0-byte file and report success.
+        json.item.result.length > 0
       ) {
         return json.item.result
       }

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -13,7 +13,6 @@ const SUBSCRIPTION_MODEL = "gpt-5.5"
 type CodexSSEEvent = {
   type?: string
   item?: { type?: string; result?: string }
-  result?: string
 }
 
 export async function parseImageGenerationResultFromSSE(stream: ReadableStream<Uint8Array>): Promise<string> {

--- a/tests/unit/codex.test.ts
+++ b/tests/unit/codex.test.ts
@@ -57,6 +57,12 @@ describe("parseImageGenerationResultFromSSE", () => {
     expect(await parseImageGenerationResultFromSSE(stream)).toBe("RESULT")
   })
 
+  test("ignores an image_generation_call whose result is an empty string", async () => {
+    // An empty result would decode to a 0-byte file and be reported as success; skip it.
+    const stream = sseStream(imageDoneEvent(""), imageDoneEvent("RESULT"))
+    expect(await parseImageGenerationResultFromSSE(stream)).toBe("RESULT")
+  })
+
   test("throws when the stream contains no image_generation result", async () => {
     const stream = sseStream(dataEvent({ type: "response.created" }), "data: [DONE]\n\n")
     expect(parseImageGenerationResultFromSSE(stream)).rejects.toThrow(


### PR DESCRIPTION
An empty `result` string passed the `typeof … === "string"` check and was returned, decoding to a 0-byte file reported as a successful generation. Now empty results are skipped so the parser falls through to a later valid event, or throws when none exists.

Also drops the unused top-level `result?: string` from `CodexSSEEvent` (only `item.result` is read).