### PR TITLE
[#36] test(e2e): flag transposed orientation as a known flake and bail on first failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "prebuild": "rm -rf dist",
     "build": "bun build ./src/index.ts --outdir ./dist --target node --format esm --packages external",
     "test": "bun test tests/unit",
-    "test:e2e_subscription": "OPENCODE_MODEL=openai/gpt-5.5 bun test tests/e2e/subscription.test.ts",
+    "test:e2e_subscription": "OPENCODE_MODEL=openai/gpt-5.5 bun test --bail tests/e2e/subscription.test.ts",
     "prepublishOnly": "bun run build",
     "release:patch": "bash scripts/prepare-release.sh patch && git push --follow-tags",
     "release:minor": "bash scripts/prepare-release.sh minor && git push --follow-tags",

--- a/tests/e2e/subscription.test.ts
+++ b/tests/e2e/subscription.test.ts
@@ -78,6 +78,20 @@ function readPngDimensions(buf: Buffer): { width: number; height: number } {
   return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) }
 }
 
+function assertDimensions(buf: Buffer, expectedWidth: number, expectedHeight: number): void {
+  const { width, height } = readPngDimensions(buf)
+  // The backend model occasionally transposes the requested orientation. The `size` string is
+  // passed correctly, so a swapped result is a known real-API flake, not a plugin regression — re-run.
+  if (width === expectedHeight && height === expectedWidth) {
+    throw new Error(
+      `expected ${expectedWidth}x${expectedHeight} but got ${width}x${height} (orientation transposed); ` +
+        `the model occasionally swaps width/height — known flake, re-run the e2e`,
+    )
+  }
+  expect(width).toBe(expectedWidth)
+  expect(height).toBe(expectedHeight)
+}
+
 describe("gpt_imagegen e2e (subscription)", () => {
   beforeAll(async () => {
     console.log(`WORKDIR: ${WORKDIR}`)
@@ -96,9 +110,7 @@ describe("gpt_imagegen e2e (subscription)", () => {
       )
       const out = path.join(WORKDIR, "character.png")
       const buf = await assertPng(out)
-      const { width, height } = readPngDimensions(buf)
-      expect(width).toBe(1024)
-      expect(height).toBe(1536)
+      assertDimensions(buf, 1024, 1536)
       console.log(`A: ${out}`)
     },
     TEST_TIMEOUT_MS,
@@ -114,9 +126,7 @@ describe("gpt_imagegen e2e (subscription)", () => {
       )
       const out = path.join(WORKDIR, "character-v2.png")
       const buf = await assertPng(out)
-      const { width, height } = readPngDimensions(buf)
-      expect(width).toBe(1536)
-      expect(height).toBe(1024)
+      assertDimensions(buf, 1536, 1024)
       console.log(`B: ${out}`)
     },
     TEST_TIMEOUT_MS,


### PR DESCRIPTION
`assertDimensions` now detects the transposed case and fails with an explicit "known flake — re-run" message instead of a bare `expect(1536).toBe(1024)`. `--bail` stops the run on the first failure, so the multi-minute Test C (which depends on A/B output) doesn't run needlessly.

Closes #36