### PR TITLE
chore: replace deprecated linter.rules.recommended with preset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -25,7 +25,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true
+      "preset": "recommended"
     }
   },
   "assist": {


### PR DESCRIPTION
Biome 2.5.0 deprecated `linter.rules.recommended` in favor of `linter.rules.preset` (https://biomejs.dev/blog/biome-v2-5/). `preset: "recommended"` enables the same rule set as `recommended: true`, so behavior is unchanged.

The replacement was done by hand instead of `biome migrate --write` because the migration can rewrite `recommended: true` to `preset: "none"` (https://github.com/biomejs/biome/issues/10716). Verified that `bunx biome ci .` passes without the deprecation info and that recommended rules (e.g. `lint/suspicious/noDebugger`) still fire.