### PR TITLE
Support remote reference image URLs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,7 +29,7 @@
 
 - The exposed tool is `gpt_imagegen`; it calls the ChatGPT Codex responses endpoint with the hosted `image_generation` tool.
 - Output paths are resolved relative to the OpenCode context directory unless absolute, and existing files are never overwritten; suffixes `-v2` through `-v999` are tried.
-- Reference images are read from paths relative to the OpenCode context directory and are embedded as data URLs after MIME detection.
+- HTTP(S) reference URLs and image data URIs pass through unchanged. Local paths resolve relative to the OpenCode context directory and are embedded as data URLs after MIME detection.
 
 ## Publishing
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,20 @@ The previous `character.png` is left untouched; the new image lands at `characte
 
 <p align="center"><img src="./assets/character-v2.png" alt="Example B output: woman in yukata, landscape (auto-versioned)" width="480" /></p>
 
-### Example C — feed existing image files as input
+### Example C — feed existing images as input
 
-Pass any number of image paths via the `images` argument and the model uses them as references for the next generation — for style guidance, characters to keep, scenes to extend, and so on.
+Pass local image paths, HTTP(S) URLs, or image data URIs via the `images`
+argument and the model uses them as references for the next generation — for
+style guidance, characters to keep, scenes to extend, and so on. Remote URLs
+are sent unchanged so the provider fetches those images directly instead of
+uploading their bytes from the OpenCode host.
 
 > Take `character.png` and `character-v2.png` and put both characters together on the engawa of an old Japanese house, smiling at the viewer. 2048x1152, same 90s anime style.
+
+For reusable references stored on a public CDN, URLs work directly:
+
+> Use `https://cdn.example.com/characters/hero-a1b2c3.webp` as the identity
+> reference and create a moonlit portrait.
 
 <p align="center"><img src="./assets/together.png" alt="Example C output: both characters composed onto an engawa" width="640" /></p>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const GptImagePlugin: Plugin = async (_input: PluginInput): Promise<Hooks> => {
           "Generate raster images using OpenAI's hosted image_generation tool.",
           "Use for AI-created bitmap visuals such as photos, illustrations, textures, sprites, and mockups.",
           "Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas.",
-          "Reference images may be attached through `images`; label each image's role inline in `prompt`, for example: 'Image 1: reference image'.",
+          "Reference images may be attached through `images` as local paths, HTTP(S) URLs, or image data URIs; label each image's role inline in `prompt`, for example: 'Image 1: reference image'.",
           "For many distinct assets, invoke gpt_imagegen once per requested asset rather than relying on multi-image output; gpt_imagegen returns one image per call.",
           "Requires OpenCode to be authenticated with ChatGPT OAuth. Returns the absolute path of the saved PNG.",
         ].join(" "),
@@ -35,7 +35,9 @@ const GptImagePlugin: Plugin = async (_input: PluginInput): Promise<Hooks> => {
           images: tool.schema
             .array(tool.schema.string())
             .optional()
-            .describe("Optional reference image paths, relative to the project directory unless absolute."),
+            .describe(
+              "Optional reference image local paths, HTTP(S) URLs, or image data URIs. Relative paths resolve from the project directory.",
+            ),
         },
         async execute(args, ctx) {
           const auth = await loadOpenAIAuth()

--- a/src/input-image.ts
+++ b/src/input-image.ts
@@ -12,9 +12,25 @@ async function readImageAsDataUrl(filePath: string, ctxDir: string): Promise<str
   return `data:${detected.mime};base64,${buf.toString("base64")}`
 }
 
-// Read the optional reference image paths and encode them as data URLs the Codex
-// backend accepts as input_image content. Paths resolve relative to the OpenCode
-// context directory unless absolute.
-export async function readReferenceImages(paths: string[] | undefined, ctxDir: string): Promise<string[]> {
-  return Promise.all((paths ?? []).map((p) => readImageAsDataUrl(p, ctxDir)))
+function resolveRemoteReference(reference: string): string | undefined {
+  if (reference.startsWith("data:image/")) return reference
+  if (/^https?:\/\//i.test(reference)) {
+    const url = new URL(reference)
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`unsupported reference image URL protocol: ${url.protocol}`)
+    }
+    return reference
+  }
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(reference)) {
+    throw new Error(`unsupported reference image URL protocol: ${new URL(reference).protocol}`)
+  }
+  return undefined
+}
+
+// Preserve remote URLs and data URIs so the Codex backend can fetch or consume
+// them directly. Local paths remain compatible and are encoded as data URLs.
+export async function readReferenceImages(references: string[] | undefined, ctxDir: string): Promise<string[]> {
+  return Promise.all(
+    (references ?? []).map((reference) => resolveRemoteReference(reference) ?? readImageAsDataUrl(reference, ctxDir)),
+  )
 }

--- a/tests/unit/input-image.test.ts
+++ b/tests/unit/input-image.test.ts
@@ -29,6 +29,22 @@ describe("readReferenceImages", () => {
     expect(await readReferenceImages(["ref.png"], dir)).toEqual([dataUrl(PNG)])
   })
 
+  test("preserves HTTP and HTTPS URLs for provider-side fetching", async () => {
+    const urls = ["https://cdn.example.test/ref.webp", "http://localhost:8080/ref.png"]
+    expect(await readReferenceImages(urls, dir)).toEqual(urls)
+  })
+
+  test("preserves image data URIs", async () => {
+    const reference = dataUrl(PNG)
+    expect(await readReferenceImages([reference], dir)).toEqual([reference])
+  })
+
+  test("rejects unsupported URL protocols", async () => {
+    expect(readReferenceImages(["ftp://example.test/ref.png"], dir)).rejects.toThrow(
+      "unsupported reference image URL protocol: ftp:",
+    )
+  })
+
   // The MIME type comes from file-type's content sniffing, not the extension, so cover a
   // few non-PNG formats to confirm the detected type (not a hard-coded "image/png") is used.
   // Each case is a minimal header file-type recognizes from its magic bytes.


### PR DESCRIPTION
## Summary

- preserve HTTP(S) reference URLs so the Codex backend fetches images directly
- preserve existing image data URIs
- retain the current MIME-detected base64 behavior for local paths
- reject unsupported URL schemes with a clear error
- document URL references in the tool schema and README

## Motivation

Repeated local reference images can add tens or hundreds of megabytes to every generation request. Passing stable public object-storage URLs avoids uploading unchanged image bytes from the OpenCode host.

## Validation

- `bun run typecheck`
- `bunx biome ci .`
- `bun run test` (44 passed)
- `bun run build`

A live project-level smoke test using two public WebP references generated successfully while the largest observed request socket sent approximately 93 KB.