### PR TITLE
feat: add WebP output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
 
 - **Subscription-friendly.** Generations ride on the same Codex backend channel OpenCode already uses for ChatGPT subscription chat — billed against your ChatGPT plan, not your API credits.
 - **Reference images.** Pass any number of input images alongside the prompt for style guidance, edit targets, or compositing inputs.
+- **WebP by default.** Generate smaller WebP files by default, or request PNG with `output_format: "png"`.
 
 ## Installation
 
@@ -36,11 +37,13 @@ OpenCode auto-installs the package via Bun on next launch — no separate `npm i
 
 Just ask your agent in natural language and `gpt_imagegen` will be picked up.
 
+The tool writes WebP by default. Use a `.webp` output path, or pass `output_format: "png"` with a `.png` path when PNG is required.
+
 The three examples below are the **actual outputs of this repo's e2e test suite** — see [`tests/e2e/subscription.test.ts`](./tests/e2e/subscription.test.ts) for the exact prompts and assertions.
 
 ### Example A — generate
 
-> Draw a man in a navy samue with a red hachimaki, standing in a garden full of cherry blossoms. 90s anime style. Save it as `character.png`, portrait 1024x1536.
+> Draw a man in a navy samue with a red hachimaki, standing in a garden full of cherry blossoms. 90s anime style. Save it as `character.png`, portrait 1024x1536, with `output_format: "png"`.
 
 <p align="center"><img src="./assets/character.png" alt="Example A output: man in samue, portrait" width="320" /></p>
 
@@ -48,7 +51,7 @@ The three examples below are the **actual outputs of this repo's e2e test suite*
 
 `gpt_imagegen` never overwrites an existing file: when the `out` path is already taken, it picks `-v2`, `-v3`, … instead.
 
-> Now do the same path but make it a woman in a yellow yukata holding a red wagasa, in a moonlit garden with fireflies. Landscape 1536x1024.
+> Now do the same path with `output_format: "png"`, but make it a woman in a yellow yukata holding a red wagasa, in a moonlit garden with fireflies. Landscape 1536x1024.
 
 The previous `character.png` is left untouched; the new image lands at `character-v2.png`.
 
@@ -58,7 +61,7 @@ The previous `character.png` is left untouched; the new image lands at `characte
 
 Pass any number of image paths via the `images` argument and the model uses them as references for the next generation — for style guidance, characters to keep, scenes to extend, and so on.
 
-> Take `character.png` and `character-v2.png` and put both characters together on the engawa of an old Japanese house, smiling at the viewer. 2048x1152, same 90s anime style.
+> Take `character.png` and `character-v2.png` and put both characters together on the engawa of an old Japanese house, smiling at the viewer. 2048x1152, same 90s anime style, with `output_format: "png"`.
 
 <p align="center"><img src="./assets/together.png" alt="Example C output: both characters composed onto an engawa" width="640" /></p>
 
@@ -72,7 +75,7 @@ Pass any number of image paths via the `images` argument and the model uses them
 
 ## How it works
 
-OpenCode already talks to the OpenAI Codex backend to power ChatGPT subscription chat. This plugin reuses that same endpoint, attaching the hosted `image_generation` tool to a single-turn request, then writes the returned PNG to disk. Auth is read from OpenCode's standard `auth.json`; no new credential surface is introduced.
+OpenCode already talks to the OpenAI Codex backend to power ChatGPT subscription chat. This plugin reuses that same endpoint, attaching the hosted `image_generation` tool to a single-turn request, then writes the returned WebP or PNG to disk. Auth is read from OpenCode's standard `auth.json`; no new credential surface is introduced.
 
 ## Disclaimer
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "opencode-gpt-imagegen",
   "version": "0.1.12",
-  "description": "OpenCode plugin for GPT Image 2 generation through your ChatGPT subscription, with reference images and safe PNG output.",
+  "description": "OpenCode plugin for GPT Image 2 generation through your ChatGPT subscription, with reference images and WebP/PNG output.",
   "type": "module",
   "main": "./dist/index.js",
   "exports": {

--- a/src/codex.ts
+++ b/src/codex.ts
@@ -1,3 +1,4 @@
+import * as path from "node:path"
 import { EventSourceParserStream } from "eventsource-parser/stream"
 import type { GenerateArgs, OpenAIAuth } from "./types"
 
@@ -44,6 +45,11 @@ export async function callViaCodexResponses(
   args: GenerateArgs,
   inputImageDataUrls: string[],
 ): Promise<string> {
+  const outputFormat = args.output_format ?? "webp"
+  if (path.extname(args.out).toLowerCase() !== `.${outputFormat}`) {
+    throw new Error(`out must use a .${outputFormat} extension`)
+  }
+
   const userContent: Array<Record<string, unknown>> = [{ type: "input_text", text: args.prompt }]
   for (const dataUrl of inputImageDataUrls) {
     userContent.push({ type: "input_image", image_url: dataUrl })
@@ -60,7 +66,7 @@ export async function callViaCodexResponses(
     tools: [
       {
         type: "image_generation",
-        output_format: "png",
+        output_format: outputFormat,
         quality: args.quality,
         ...(args.size ? { size: args.size } : {}),
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,17 +15,23 @@ const GptImagePlugin: Plugin = async (_input: PluginInput): Promise<Hooks> => {
           "Do not use when the task is better handled by editing existing SVG/vector/code-native assets, extending an established icon or logo system, or building the visual directly in HTML/CSS/canvas.",
           "Reference images may be attached through `images`; label each image's role inline in `prompt`, for example: 'Image 1: reference image'.",
           "For many distinct assets, invoke gpt_imagegen once per requested asset rather than relying on multi-image output; gpt_imagegen returns one image per call.",
-          "Requires OpenCode to be authenticated with ChatGPT OAuth. Returns the absolute path of the saved PNG.",
+          "Requires OpenCode to be authenticated with ChatGPT OAuth. Returns the absolute path of the saved image.",
         ].join(" "),
         // https://developers.openai.com/api/docs/guides/image-generation
         args: {
           prompt: tool.schema.string().describe("Description of the image to generate."),
           out: tool.schema
             .string()
-            .describe("Output file path, relative to the project directory unless absolute. The plugin writes a PNG."),
+            .describe(
+              "Output file path, relative to the project directory unless absolute. Use an extension matching output_format.",
+            ),
           quality: tool.schema
             .enum(["low", "medium", "high", "auto"])
             .describe("Generation quality passed to the hosted image_generation tool."),
+          output_format: tool.schema
+            .enum(["png", "webp"])
+            .optional()
+            .describe("Output image format. Defaults to webp."),
           size: tool.schema
             .string()
             .optional()

--- a/src/output-image.ts
+++ b/src/output-image.ts
@@ -38,7 +38,7 @@ export function buildSavedMessage(savedPath: string, requestedPath: string): str
 type SaveResult = { savedPath: string; versioned: boolean; message: string }
 
 // Resolve the output path (relative to ctxDir unless absolute), then write the
-// decoded PNG. Avoiding an overwrite is best-effort: the collision check and the
+// decoded image. Avoiding an overwrite is best-effort: the collision check and the
 // write are not atomic, so a concurrent writer racing between them could still be
 // clobbered. Returns the user-facing message alongside the saved path.
 export async function saveGeneratedImage(out: string, ctxDir: string, base64: string): Promise<SaveResult> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,7 @@ export type GenerateArgs = {
   prompt: string
   out: string
   quality: "low" | "medium" | "high" | "auto"
+  output_format?: "png" | "webp"
   size?: string
   images?: string[]
 }

--- a/tests/e2e/subscription.test.ts
+++ b/tests/e2e/subscription.test.ts
@@ -92,7 +92,7 @@ describe("gpt_imagegen e2e (subscription)", () => {
       await runOpencode(
         `Use the gpt_imagegen tool to generate an image at character.png. ` +
           `Content: a man wearing a navy-blue samue and a red hachimaki headband, standing in a garden of cherry blossoms in full bloom. ` +
-          `Style: ${STYLE}. Size: 1024x1536 (portrait). Quality: medium.`,
+          `Style: ${STYLE}. Size: 1024x1536 (portrait). Quality: medium. Output format: png.`,
       )
       const out = path.join(WORKDIR, "character.png")
       const buf = await assertPng(out)
@@ -110,7 +110,7 @@ describe("gpt_imagegen e2e (subscription)", () => {
       await runOpencode(
         `Use the gpt_imagegen tool to generate an image at character.png. ` +
           `Content: a woman wearing a yellow yukata and holding a red wagasa parasol, standing in a garden at night with fireflies dancing around her. ` +
-          `Style: ${STYLE}. Size: 1536x1024 (landscape). Quality: medium.`,
+          `Style: ${STYLE}. Size: 1536x1024 (landscape). Quality: medium. Output format: png.`,
       )
       const out = path.join(WORKDIR, "character-v2.png")
       const buf = await assertPng(out)
@@ -131,7 +131,7 @@ describe("gpt_imagegen e2e (subscription)", () => {
           `Content: the man from Image 1 (navy samue + red hachimaki) and the woman from Image 2 (yellow yukata + red wagasa) standing side by side ` +
           `on the engawa veranda of an old Japanese house, smiling at the viewer. ` +
           `Preserve each character's outfit, hairstyle, and props exactly. ` +
-          `Style: ${STYLE}. Size: 2048x1152. Quality: medium.`,
+          `Style: ${STYLE}. Size: 2048x1152. Quality: medium. Output format: png.`,
       )
       const out = path.join(WORKDIR, "together.png")
       await assertPng(out)

--- a/tests/unit/codex.test.ts
+++ b/tests/unit/codex.test.ts
@@ -82,7 +82,13 @@ describe("callViaCodexResponses", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const auth = { type: "oauth", access: "tok", accountId: "acct" } as const
-    const args: GenerateArgs = { prompt: "a cat", out: "cat.png", quality: "high", size: "1024x1024" }
+    const args: GenerateArgs = {
+      prompt: "a cat",
+      out: "cat.png",
+      quality: "high",
+      output_format: "png",
+      size: "1024x1024",
+    }
     const result = await callViaCodexResponses(auth, args, ["data:image/png;base64,AAA"])
 
     expect(result).toBe("PARSED")
@@ -122,14 +128,27 @@ describe("callViaCodexResponses", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const auth = { type: "oauth", access: "tok" } as const
-    const args: GenerateArgs = { prompt: "a cat", out: "cat.png", quality: "auto" }
+    const args: GenerateArgs = { prompt: "a cat", out: "cat.webp", quality: "auto" }
     await callViaCodexResponses(auth, args, [])
 
     const [, init] = fetchMock.mock.calls[0]
     expect(init.headers as Record<string, string>).not.toHaveProperty("ChatGPT-Account-Id")
     const body = JSON.parse(init.body as string)
     expect(body.tools[0]).not.toHaveProperty("size")
+    expect(body.tools[0].output_format).toBe("webp")
     expect(body.input[0].content).toEqual([{ type: "input_text", text: "a cat" }])
+  })
+
+  test.each([
+    [{ prompt: "a cat", out: "cat.png", quality: "auto" } satisfies GenerateArgs, ".webp"],
+    [{ prompt: "a cat", out: "cat.webp", quality: "auto", output_format: "png" } satisfies GenerateArgs, ".png"],
+  ])("rejects an output path that does not match the format", async (args, expectedExtension) => {
+    const fetchMock = mock(async (_url: string, _init: RequestInit) => new Response(imageDoneEvent("PARSED")))
+    globalThis.fetch = fetchMock as unknown as typeof fetch
+
+    const auth = { type: "oauth", access: "tok" } as const
+    expect(callViaCodexResponses(auth, args, [])).rejects.toThrow(`out must use a ${expectedExtension} extension`)
+    expect(fetchMock).not.toHaveBeenCalled()
   })
 
   test("throws with the status and response body when the request fails", async () => {
@@ -137,7 +156,7 @@ describe("callViaCodexResponses", () => {
     globalThis.fetch = fetchMock as unknown as typeof fetch
 
     const auth = { type: "oauth", access: "tok" } as const
-    const args: GenerateArgs = { prompt: "a cat", out: "cat.png", quality: "auto" }
+    const args: GenerateArgs = { prompt: "a cat", out: "cat.webp", quality: "auto" }
     expect(callViaCodexResponses(auth, args, [])).rejects.toThrow("codex responses request failed: 500 upstream boom")
   })
 })


### PR DESCRIPTION
## Summary
- expose `output_format` with `webp` and `png` options
- default new generations to WebP while retaining explicit PNG output
- reject mismatched output extensions before making a backend request
- update documentation and existing PNG E2E prompts

## Validation
- `bun run test` (43 passed)
- `bun run typecheck`
- `bunx biome ci .`
- `bun run build`
- focused subscription-backed generation produced a valid RIFF/WEBP image at high quality